### PR TITLE
Attempt to fix nvm/npm command not found errors

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,9 @@ sudo apt install -y build-essential git curl
 # Install Node Version Manager
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
 
-source ~/.bashrc
+# Load nvm so that we have access to the nvm shell command
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
 # Install version v8.2.1 of the `$ node` command
 nvm install v8.2.1


### PR DESCRIPTION
Instead of trying to source the entire `~/.bashrc`, just explicitly run the parts of it that we need in order to have access to the `nvm` and `npm` commands.

This is a workaround to an issue where some platforms come with a `~/.bashrc` that has a conditional at the top that explicitly stops processing if the shell is found to be non-interactive. On those platforms our `setup.sh` script was not working due to that.